### PR TITLE
Script de movimiento de cámara

### DIFF
--- a/bin/assets/scripts/CameraScript.lua
+++ b/bin/assets/scripts/CameraScript.lua
@@ -1,0 +1,12 @@
+-- defines a factorial function
+    function fact (n)
+      if n == 0 then
+        return 1
+      else
+        return n * fact(n-1)
+      end
+    end
+    
+    print("enter a number:")
+    a = io.read("*number")        -- read a number
+    print(fact(a))

--- a/bin/assets/scripts/CameraScript.lua
+++ b/bin/assets/scripts/CameraScript.lua
@@ -1,32 +1,25 @@
--- defines a factorial function
-    --print("enter a number:")
-    --a = io.read("*number")        -- read a number
-    --print(fact(a))
-
     function Update (n)
+      --You first need to define this class in C++
+      --If you're creating a variable just for this .lua please 
+      --define it as a local variable.
       local dir = vec3:new(0, 0, 0)
-      if keyPressed(4) then
-        print("a")
-        --Llama a mover
+      if keyPressed(PTSDKeys.A) then
         dir = vec3:new(-1, 0, 0)
         translate(dir)
       end
-      if keyPressed(26) then
-        print("w")
+      if keyPressed(PTSDKeys.W) then
         dir = vec3:new(0, 0, -1)
         translate(dir)
       end
-      if keyPressed(22) then
-        print("s")
+      if keyPressed(PTSDKeys.S) then
         dir = vec3:new(0, 0, 1)
         translate(dir)
       end
-      if keyPressed(7) then
-        print("d")
+      if keyPressed(PTSDKeys.D) then
         dir = vec3:new(1, 0, 0)
         translate(dir)
       end
       return true
     end
 
-    Exit = false  --O se lo pones a Lua o se enfada
+    Exit = false  --Please keep this or Lua explodes

--- a/bin/assets/scripts/CameraScript.lua
+++ b/bin/assets/scripts/CameraScript.lua
@@ -4,22 +4,27 @@
     --print(fact(a))
 
     function Update (n)
+      local dir = vec3:new(0, 0, 0)
       if keyPressed(4) then
         print("a")
         --Llama a mover
-        translate({-1,0,0})
+        dir = vec3:new(-1, 0, 0)
+        translate(dir)
       end
       if keyPressed(26) then
         print("w")
-        translate({0,0,-1})
+        dir = vec3:new(0, 0, -1)
+        translate(dir)
       end
       if keyPressed(22) then
         print("s")
-        translate({0,0,-1})
+        dir = vec3:new(0, 0, 1)
+        translate(dir)
       end
       if keyPressed(7) then
         print("d")
-        translate({1,0,0})
+        dir = vec3:new(1, 0, 0)
+        translate(dir)
       end
       return true
     end

--- a/bin/assets/scripts/CameraScript.lua
+++ b/bin/assets/scripts/CameraScript.lua
@@ -1,12 +1,27 @@
 -- defines a factorial function
-    function fact (n)
-      if n == 0 then
-        return 1
-      else
-        return n * fact(n-1)
+    --print("enter a number:")
+    --a = io.read("*number")        -- read a number
+    --print(fact(a))
+
+    function Update (n)
+      if keyPressed(4) then
+        print("a")
+        --Llama a mover
+        translate({-1,0,0})
       end
+      if keyPressed(26) then
+        print("w")
+        translate({0,0,-1})
+      end
+      if keyPressed(22) then
+        print("s")
+        translate({0,0,-1})
+      end
+      if keyPressed(7) then
+        print("d")
+        translate({1,0,0})
+      end
+      return true
     end
-    
-    print("enter a number:")
-    a = io.read("*number")        -- read a number
-    print(fact(a))
+
+    Exit = false  --O se lo pones a Lua o se enfada

--- a/source/Core/src/main.cpp
+++ b/source/Core/src/main.cpp
@@ -37,7 +37,7 @@ int main()
 	PTSD::LOG("All subsystems initialized");
 	PTSD::Camera* myCam = graphicsSystem->getCam();
 
-	scriptingSystem->run("CameraScript");
+	scriptingSystem->run("CameraScript.lua");
 
 	//GAME LOOP (all times in miliseconds)
 	bool running = true;
@@ -58,11 +58,13 @@ int main()
 			scriptingSystem->update();
 
 			physicsSystem->update();
-			graphicsSystem->getCam()->translate({ 0,0,0.1 });
+			//graphicsSystem->getCam()->translate({ 0,0,0.1 });
 			//scriptingSystem->update(); Prob� a ponerlo pero al hacer update revienta (?)
 			soundSystem->update();
 			//PTSD::LOG("update cycle complete", PTSD::Warning);
 			accumulator -= deltaTime;
+
+			running = !inputSystem->keyPressed(Scancode::SCANCODE_ESCAPE);
 		}
 		graphicsSystem->renderFrame(); //The frame is rendered even if the game has not been updated (for faster machines)
 		uiSystem->render();

--- a/source/Core/src/main.cpp
+++ b/source/Core/src/main.cpp
@@ -37,6 +37,8 @@ int main()
 	PTSD::LOG("All subsystems initialized");
 	PTSD::Camera* myCam = graphicsSystem->getCam();
 
+	scriptingSystem->run("CameraScript");
+
 	//GAME LOOP (all times in miliseconds)
 	bool running = true;
 	Uint32 deltaTime = 33; //33 miliseconds per frame, ~30fps
@@ -52,6 +54,9 @@ int main()
 
 		while (accumulator>= deltaTime) { //The loop is executed only if it's time to proccess another cycle
 			inputSystem->update();
+
+			scriptingSystem->update();
+
 			physicsSystem->update();
 			graphicsSystem->getCam()->translate({ 0,0,0.1 });
 			//scriptingSystem->update(); Prob� a ponerlo pero al hacer update revienta (?)

--- a/source/Graphics/source/GraphicsImplementation.cpp
+++ b/source/Graphics/source/GraphicsImplementation.cpp
@@ -221,7 +221,7 @@ namespace PTSD
 		deltaTime = double(SDL_GetTicks() - lastRenderTime) / 1000;
 		lastRenderTime = SDL_GetTicks();
 
-		LOG("Frame rendered", Trace);
+		//LOG("Frame rendered", Trace);
 
 		return true;
 	}

--- a/source/Scripting/include/ScriptingImplementation.h
+++ b/source/Scripting/include/ScriptingImplementation.h
@@ -13,6 +13,7 @@ namespace PTSD
 		bool bindUIComponents();
 		bool bindSoundComponents();
 		bool bindInputComponents();
+		bool bindGenericComponents();
 	public:
 		ScriptingImplementation();
 		virtual ~ScriptingImplementation() = default;

--- a/source/Scripting/include/ScriptingImplementation.h
+++ b/source/Scripting/include/ScriptingImplementation.h
@@ -12,6 +12,7 @@ namespace PTSD
 		bool bindPhysicsComponents();
 		bool bindUIComponents();
 		bool bindSoundComponents();
+		bool bindInputComponents();
 	public:
 		ScriptingImplementation();
 		virtual ~ScriptingImplementation() = default;

--- a/source/Scripting/source/PTSDScripting.cpp
+++ b/source/Scripting/source/PTSDScripting.cpp
@@ -2,6 +2,7 @@
 #include "PTSDScripting.h"
 #include "ScriptingImplementation.h"
 #include "lua.hpp"
+#include "PTSDLog.h"
 #include "sol/sol.hpp"
 
 namespace PTSD {
@@ -29,6 +30,8 @@ namespace PTSD {
 
 	void Scripting::run(std::string script)
 	{
+		std::string mssg = script + " loading... @PTSDScripting, Run()";
+		PTSD::LOG(mssg.c_str(), PTSD::Info);
 		mScriptMgr->run(script);
 	}
 

--- a/source/Scripting/source/PTSDScripting.cpp
+++ b/source/Scripting/source/PTSDScripting.cpp
@@ -30,8 +30,6 @@ namespace PTSD {
 
 	void Scripting::run(std::string script)
 	{
-		std::string mssg = script + " loading... @PTSDScripting, Run()";
-		PTSD::LOG(mssg.c_str(), PTSD::Info);
 		mScriptMgr->run(script);
 	}
 

--- a/source/Scripting/source/ScriptingImplementation.cpp
+++ b/source/Scripting/source/ScriptingImplementation.cpp
@@ -10,6 +10,7 @@ Include every PTSD-System to expose its public API to our Scripting state
 //#include "PTSDPhysics.h"
 #include "PTSDScripting.h" //debería ser el ECS
 #include "PTSDVectors.h"
+#include "PTSDLog.h"
 
 namespace PTSD {
 	ScriptingImplementation::ScriptingImplementation() {
@@ -32,7 +33,8 @@ namespace PTSD {
 			bindPhysicsComponents() &&
 			bindUIComponents() &&
 			bindSoundComponents() &&
-			bindInputComponents()) {
+			bindInputComponents() &&
+			bindGenericComponents()) {
 			//state.do_file("./assets/PTSDComponents.lua");
 			//state.do_file("./assets/UserComponent.lua");
 			// state["Start"]();
@@ -69,32 +71,54 @@ namespace PTSD {
 	bool ScriptingImplementation::bindGraphicsComponents()
 	{
 		//Init everything
+		PTSD::LOG("Binding LUA Graphics Components... @ScriptingImplementation, BindGraphicsComponents()");
+
 		state.set_function("translate", &PTSD::Camera::translate , PTSD::Graphics::getInstance()->getCam());
-		state.new_usertype<Vec3Placeholder>("vec3", sol::constructors<Vec3Placeholder(float, float, float)>());
+
 		return true;
 	}
 	bool ScriptingImplementation::bindPhysicsComponents()
 	{
 		//Init everything
+		PTSD::LOG("Binding LUA Physics Components... @ScriptingImplementation, BindPhysicsComponents()");
 		return true;
 	}
 	bool ScriptingImplementation::bindSoundComponents()
 	{
 		//Init everything
+		PTSD::LOG("Binding LUA Sound Components... @ScriptingImplementation, BindSoundComponents()");
 		return true;
 	}
 	bool ScriptingImplementation::bindUIComponents()
 	{
 		//Init everything
+		PTSD::LOG("Binding LUA UI Components... @ScriptingImplementation, BindUIComponents()");
 		return true;
 	}
-
-	
 	bool ScriptingImplementation::bindInputComponents()
 	{
 		//Init everything
+		PTSD::LOG("Binding LUA Input Components... @ScriptingImplementation, BindInputComponents()");
+
 		state.set_function("keyPressed", &PTSD::Input::keyPressed, PTSD::Input::getInstance());
-		//state.new_enum()
+
+		//This should be expanded or reconsidered in the future.
+		state.new_enum<Scancode>("PTSDKeys", {
+			{"W", Scancode::SCANCODE_W},
+			{"A", Scancode::SCANCODE_A},
+			{"S", Scancode::SCANCODE_S},
+			{"D", Scancode::SCANCODE_D}
+		});
+
+		return true;
+	}
+	bool ScriptingImplementation::bindGenericComponents()
+	{
+		//Init everything
+		PTSD::LOG("Binding Generic Components... @ScriptingImplementation, BindGenericComponents()");
+
+		state.new_usertype<Vec3Placeholder>("vec3", sol::constructors<Vec3Placeholder(float, float, float)>());
+
 		return true;
 	}
 }

--- a/source/Scripting/source/ScriptingImplementation.cpp
+++ b/source/Scripting/source/ScriptingImplementation.cpp
@@ -19,6 +19,9 @@ namespace PTSD {
 
 	void ScriptingImplementation::run(std::string scriptFile)
 	{
+		std::string mssg = scriptFile + " loading... @PTSDScripting, Run()";
+		PTSD::LOG(mssg.c_str(), PTSD::Info);
+
 		state.do_file("./assets/scripts/" + scriptFile);
 	}
 

--- a/source/Scripting/source/ScriptingImplementation.cpp
+++ b/source/Scripting/source/ScriptingImplementation.cpp
@@ -9,6 +9,7 @@ Include every PTSD-System to expose its public API to our Scripting state
 //#include "PTSDUI.h"
 //#include "PTSDPhysics.h"
 #include "PTSDScripting.h" //debería ser el ECS
+#include "PTSDVectors.h"
 
 namespace PTSD {
 	ScriptingImplementation::ScriptingImplementation() {
@@ -69,6 +70,7 @@ namespace PTSD {
 	{
 		//Init everything
 		state.set_function("translate", &PTSD::Camera::translate , PTSD::Graphics::getInstance()->getCam());
+		state.new_usertype<Vec3Placeholder>("vec3", sol::constructors<Vec3Placeholder(float, float, float)>());
 		return true;
 	}
 	bool ScriptingImplementation::bindPhysicsComponents()

--- a/source/Scripting/source/ScriptingImplementation.cpp
+++ b/source/Scripting/source/ScriptingImplementation.cpp
@@ -5,6 +5,7 @@ Include every PTSD-System to expose its public API to our Scripting state
 */
 #include "PTSDInput.h"
 #include "PTSDGraphics.h"
+#include "Camera.h"
 //#include "PTSDUI.h"
 //#include "PTSDPhysics.h"
 #include "PTSDScripting.h" //debería ser el ECS
@@ -29,7 +30,8 @@ namespace PTSD {
 		if (bindGraphicsComponents() &&
 			bindPhysicsComponents() &&
 			bindUIComponents() &&
-			bindSoundComponents()) {
+			bindSoundComponents() &&
+			bindInputComponents()) {
 			//state.do_file("./assets/PTSDComponents.lua");
 			//state.do_file("./assets/UserComponent.lua");
 			// state["Start"]();
@@ -66,6 +68,7 @@ namespace PTSD {
 	bool ScriptingImplementation::bindGraphicsComponents()
 	{
 		//Init everything
+		state.set_function("translate", &PTSD::Camera::translate , PTSD::Graphics::getInstance()->getCam());
 		return true;
 	}
 	bool ScriptingImplementation::bindPhysicsComponents()
@@ -81,6 +84,15 @@ namespace PTSD {
 	bool ScriptingImplementation::bindUIComponents()
 	{
 		//Init everything
+		return true;
+	}
+
+	
+	bool ScriptingImplementation::bindInputComponents()
+	{
+		//Init everything
+		state.set_function("keyPressed", &PTSD::Input::keyPressed, PTSD::Input::getInstance());
+		//state.new_enum()
 		return true;
 	}
 }


### PR DESCRIPTION
**Ahora se puede mover la cámara con las teclas WASD.**
El script está localizado en bin/assets/scripts bajo el nombre de CameraScript.

Hemos modificado la clase ScriptImplementation:
 -Enum de ScanCodes de SDL para que lo lea LUA 
     (Ahora mismo hay que añadir cada tecla a pelo lo cual es un poco engorroso. Se puede reconsiderar en el futuro)
 -Intérprete en LUA de la clase Vec3Placeholder
 -Se llama el update y el run de ScriptingSystem en Main (Colleja)
 -Mensajes de Log en los bindings de ScriptingImplementation

Ahora se puede apreciar mejor al ogro .. . . .
