### PR TITLE
Delete de entidades reflejado

### DIFF
--- a/bin/assets/scripts/Client/SystemsList.lua
+++ b/bin/assets/scripts/Client/SystemsList.lua
@@ -202,10 +202,11 @@ end
 function BulletSystem:update(dt)
 	for _, entity in pairs(self.targets) do
 		local bulletInfo = entity:get("bullet")
-		if(bulletInfo.lifetime > 0) then
 		local movement = vec3:new(bulletInfo.speed*dt,0,0)
 		entity.Transform:translate(movement)
 		bulletInfo.lifetime = bulletInfo.lifetime - 1
+		if(bulletInfo.lifetime <= 0) then
+			Manager:removeEntity(entity)
 		end
 	end
 	self.collided = {}

--- a/bin/assets/scripts/Engine/EntityManager.lua
+++ b/bin/assets/scripts/Engine/EntityManager.lua
@@ -80,6 +80,9 @@ function EntityManager:removeEntity(entity)
 		-- Finally remove entity
 		self.entities[entity.id] = nil
 	end
+
+	--Delete entity in cpp
+	PTSDDeleteEntity(entity.id)
 end
 
 function EntityManager:addSystem(system)

--- a/source/Physics/include/PhysicsManager.h
+++ b/source/Physics/include/PhysicsManager.h
@@ -29,7 +29,6 @@ namespace PTSD {
 		btSequentialImpulseConstraintSolver* mSolver;
 		btDiscreteDynamicsWorld* mWorld;
 		BtOgre::CollisionListener* mCollisionListener;
-		void testScene();
 		void logActivity();
 	public:
 		void setScriptManager(ScriptManager* sm) {mScriptManager = sm;}
@@ -52,6 +51,9 @@ namespace PTSD {
 		BtOgre::CollisionListener* getCollisionListener() const {return mCollisionListener;}
 
 		btRigidBody* addRigidBody(Vec3 size, float mass, Vec3 pos, Vec3 rot = { 0,0,0 });
+
+		void removeCollision(btRigidBody* body);
+		void removeRigidBody(btRigidBody* body);
 
 		void setCollisionFlags(btRigidBody* rb, CollisionFlags type, bool trigger);
 

--- a/source/Physics/source/PhysicsManager.cpp
+++ b/source/Physics/source/PhysicsManager.cpp
@@ -84,6 +84,26 @@ namespace PTSD {
 		mWorld->addRigidBody(mObj);
 		return mObj;
 	}
+
+	void PhysicsManager::removeCollision(btRigidBody* body)
+	{
+		mWorld->removeCollisionObject(body);
+	}
+
+	void PhysicsManager::removeRigidBody(btRigidBody* body)
+	{
+		//Constraints not added
+
+		if (body->getMotionState()) {
+			delete body->getMotionState();
+		}
+
+		delete body->getCollisionShape();
+		delete (BtOgre::EntityCollisionListener*)body->getUserPointer();
+		mWorld->removeRigidBody(body);
+		delete body;
+	}
+
 	void PhysicsManager::setCollisionFlags(btRigidBody* rb, CollisionFlags type, bool trigger) {
 		if (trigger) rb->setCollisionFlags(type | CollisionFlags::Trigger);
 		else rb->setCollisionFlags(type);

--- a/source/Scripting/include/Component.h
+++ b/source/Scripting/include/Component.h
@@ -20,6 +20,7 @@ namespace PTSD
 		CmpId getId() { return id_; }
 		virtual void init() {}
 		virtual void update() {}
+		virtual void disable() {}
 		virtual void onCollisionEnter(Collision* collision) {}
 		virtual void onCollisionStay(Collision* collision) {}
 		virtual void onCollisionExit(Collision* collision) {}

--- a/source/Scripting/include/Component.h
+++ b/source/Scripting/include/Component.h
@@ -15,11 +15,11 @@ namespace PTSD
 		Component(CmpId id) :
 			id_(id) {}
 	public:
+		virtual ~Component() = default;
 		void setEntity(Entity* entity) { entity_ = entity; }
 		CmpId getId() { return id_; }
 		virtual void init() {}
 		virtual void update() {}
-		virtual void destroy() {}
 		virtual void onCollisionEnter(Collision* collision) {}
 		virtual void onCollisionStay(Collision* collision) {}
 		virtual void onCollisionExit(Collision* collision) {}

--- a/source/Scripting/include/Entity.h
+++ b/source/Scripting/include/Entity.h
@@ -19,7 +19,6 @@ namespace PTSD {
 		EntityManager* entityManager_ = nullptr;
 		std::vector<std::unique_ptr<Component>> components_;
 		std::array<Component*, CmpId::MAXCOMPONENTS> componentPtrs_ = {};
-		//TODO add reference to lua entity
 	public:
 		//Component methods
 		template<typename T, typename ... TArgs>
@@ -39,6 +38,8 @@ namespace PTSD {
 		bool hasComponent(CmpId id) const {
 			return componentPtrs_[id] != nullptr;
 		}
+
+		~Entity() { components_.clear(); }
 
 		//Runtime loop methods
 		void init()

--- a/source/Scripting/include/Entity.h
+++ b/source/Scripting/include/Entity.h
@@ -15,7 +15,6 @@ namespace PTSD {
 	class Entity {
 	private:
 		UUID id_;
-		bool active_;
 		EntityManager* entityManager_ = nullptr;
 		std::vector<std::unique_ptr<Component>> components_;
 		std::array<Component*, CmpId::MAXCOMPONENTS> componentPtrs_ = {};
@@ -39,7 +38,9 @@ namespace PTSD {
 			return componentPtrs_[id] != nullptr;
 		}
 
-		~Entity() { components_.clear(); }
+		~Entity() {
+			components_.clear();
+		}
 
 		//Runtime loop methods
 		void init()
@@ -68,12 +69,10 @@ namespace PTSD {
 				cmp->onCollisionExit(col);
 		}
 
-		//Getters and Setters
-		void setActive(bool active = true) { active_ = active; }
-		bool isActive() { return active_; }
 		UUID getID() { return id_; }
-		Entity(UUID id, bool active = true) :
-			id_(id), active_(active) {}
+		Entity(UUID id) : id_(id) {}
 		EntityManager* getManager() const { return entityManager_; }
+
+		void disableEntity();
 	};
 }

--- a/source/Scripting/include/MeshComponent.h
+++ b/source/Scripting/include/MeshComponent.h
@@ -11,6 +11,7 @@ namespace PTSD {
 		MeshComponent(const std::string&);
 		MeshComponent(const std::string&, const std::string&);
 		virtual void init() override;
+		virtual void disable() override;
 		void setMesh(const std::string& mesh);
 		void setMaterial(const std::string& material);
 		const std::string getMesh() { return mMesh_; };

--- a/source/Scripting/include/RigidbodyComponent.h
+++ b/source/Scripting/include/RigidbodyComponent.h
@@ -32,6 +32,7 @@ namespace PTSD
 		virtual ~RigidbodyComponent();
 
 		virtual void init();
+		virtual void disable() override;
 
 		void setLinearVelocity(Vec3 vel);
 		void setAngularVelocity(Vec3 vel);

--- a/source/Scripting/include/RigidbodyComponent.h
+++ b/source/Scripting/include/RigidbodyComponent.h
@@ -29,7 +29,7 @@ namespace PTSD
 		}
 	public:
 		RigidbodyComponent(Vec3 size, float mass, Vec3 pos, CollisionFlags type = CollisionFlags::Dynamic, bool trigger = false, Vec3 rot = { 0,0,0 });
-		~RigidbodyComponent() = default;
+		virtual ~RigidbodyComponent();
 
 		virtual void init();
 

--- a/source/Scripting/include/TransformComponent.h
+++ b/source/Scripting/include/TransformComponent.h
@@ -22,7 +22,9 @@ namespace PTSD {
 	public:
 		TransformComponent();
 		TransformComponent(Vec3 p, Vec3 r, Vec3 s);
-		~TransformComponent() = default;
+		~TransformComponent();
+
+		void DestroyNodeAndChildren(Ogre::SceneNode* node);
 
 		void translate(Vec3 translation);
 		void translate(float x, float y, float z);

--- a/source/Scripting/source/Entity.cpp
+++ b/source/Scripting/source/Entity.cpp
@@ -1,0 +1,16 @@
+#include "Entity.h"
+
+void PTSD::Entity::disableEntity()
+{
+	//LOG("Disabling entity");
+	//Hide mesh
+	if (componentPtrs_[CmpId::Mesh] != nullptr) {
+		componentPtrs_[CmpId::Mesh]->disable();
+	}
+
+
+	//Disable collision
+	if (componentPtrs_[CmpId::RigidbodyC] != nullptr) {
+		componentPtrs_[CmpId::RigidbodyC]->disable();
+	}
+}

--- a/source/Scripting/source/EntityManager.cpp
+++ b/source/Scripting/source/EntityManager.cpp
@@ -36,6 +36,9 @@ void PTSD::EntityManager::deleteEntity(UUID entityID)
 	auto it = entities_.find(entityID);
 	if(it!=entities_.end())
 	{
+		//We make sure we hide the node and delete the rigibody before the trash collector takes care of everything else
+		//this is because if we wait there might be problems if we have to wait for the whole system to delete each individual component
+		it->second->disableEntity();
 		entities_.erase(it);
 	}
 }

--- a/source/Scripting/source/MeshComponent.cpp
+++ b/source/Scripting/source/MeshComponent.cpp
@@ -37,6 +37,12 @@ namespace PTSD {
 		PTSD::LOG(mMaterial_.c_str());
 		ob->setMaterialName(mMaterial_);
 	}
+
+	void MeshComponent::disable()
+	{
+		sceneNode->setVisible(false);
+	}
+
 	void MeshComponent::setMaterial(const std::string& material)
 	{
 		if (material != mMaterial_)

--- a/source/Scripting/source/RigidbodyComponent.cpp
+++ b/source/Scripting/source/RigidbodyComponent.cpp
@@ -14,6 +14,11 @@ namespace PTSD
 		PhysicsManager::getInstance()->setCollisionFlags(mObj, type, trigger);
 	}
 
+	RigidbodyComponent::~RigidbodyComponent()
+	{
+
+	}
+
 	void RigidbodyComponent::init() {
 		rbState = new BtOgre::RigidBodyState(entity_->getComponent<TransformComponent>(CmpId::Transform)->getNode());
 		mObj->setMotionState(rbState);

--- a/source/Scripting/source/RigidbodyComponent.cpp
+++ b/source/Scripting/source/RigidbodyComponent.cpp
@@ -16,13 +16,19 @@ namespace PTSD
 
 	RigidbodyComponent::~RigidbodyComponent()
 	{
-
+		//LOG("deleting rb");
+		PhysicsManager::getInstance()->removeRigidBody(mObj);
 	}
 
 	void RigidbodyComponent::init() {
 		rbState = new BtOgre::RigidBodyState(entity_->getComponent<TransformComponent>(CmpId::Transform)->getNode());
 		mObj->setMotionState(rbState);
 		mObj->setUserPointer((void*)(new BtOgre::EntityCollisionListener(PhysicsManager::getInstance()->getCollisionListener(), entity_->getID())));
+	}
+
+	void RigidbodyComponent::disable()
+	{
+		PhysicsManager::getInstance()->removeCollision(mObj);
 	}
 
 	void RigidbodyComponent::setLinearVelocity(Vec3 vel) {

--- a/source/Scripting/source/ScriptManager.cpp
+++ b/source/Scripting/source/ScriptManager.cpp
@@ -150,8 +150,6 @@ namespace PTSD {
 	void ScriptManager::deleteEntity(UUID entityID)
 	{
 		entityManager->deleteEntity(entityID);
-		//Deletes entity in Lua
-		//Entity["Delete"]();
 	}
 	std::shared_ptr<Entity> ScriptManager::getEntity(UUID entityID)
 	{
@@ -335,6 +333,7 @@ namespace PTSD {
 	}
 	bool ScriptManager::bindScriptingComponents() {
 		(*state).set_function("PTSDCreateEntity", &PTSD::ScriptManager::createEntity, this);
+		(*state).set_function("PTSDDeleteEntity", &PTSD::ScriptManager::deleteEntity, this);
 
 		return true;
 	}

--- a/source/Scripting/source/TransformComponent.cpp
+++ b/source/Scripting/source/TransformComponent.cpp
@@ -32,6 +32,35 @@ namespace PTSD {
 		setScale(s);
 	}
 
+	TransformComponent::~TransformComponent()
+	{
+		//Since Transform handles the base node for all ogre based things we do this here.
+		DestroyNodeAndChildren(mNode);
+	}
+
+	void TransformComponent::DestroyNodeAndChildren(Ogre::SceneNode* node)
+	{
+		//Destroy all the attached objects
+		Ogre::SceneNode::ObjectIterator itObject = node->getAttachedObjectIterator();
+
+		while (itObject.hasMoreElements())
+		{
+			Ogre::MovableObject* pObject = static_cast<Ogre::MovableObject*>(itObject.getNext());
+			node->getCreator()->destroyMovableObject(pObject);
+		}
+
+		// Recurse to child SceneNodes
+		Ogre::SceneNode::ChildNodeIterator itChild = node->getChildIterator();
+
+		while (itChild.hasMoreElements())
+		{
+			Ogre::SceneNode* pChildNode = static_cast<Ogre::SceneNode*>(itChild.getNext());
+			DestroyNodeAndChildren(pChildNode);
+		}
+		node->removeAndDestroyAllChildren();
+		GraphicsImplementation::getInstance()->getSceneMgr()->destroySceneNode(node);
+	}
+
 
 	void TransformComponent::translate(Vec3 translation) { //moves the transform with a vec3
 		mNode->translate(translation.x, translation.y, translation.z, Ogre::Node::TS_WORLD);

--- a/vsprojects/PTSD-Core/PTSD.vcxproj
+++ b/vsprojects/PTSD-Core/PTSD.vcxproj
@@ -23,6 +23,7 @@
     <ClCompile Include="..\..\source\Logger\source\PTSDAssert.cpp" />
     <ClCompile Include="..\..\source\Logger\source\LogManager.cpp" />
     <ClCompile Include="..\..\source\Physics\source\PhysicsManager.cpp" />
+    <ClCompile Include="..\..\source\Scripting\source\Entity.cpp" />
     <ClCompile Include="..\..\source\Scripting\source\EntityManager.cpp" />
     <ClCompile Include="..\..\source\Scripting\source\MeshComponent.cpp" />
     <ClCompile Include="..\..\source\Scripting\source\RigidbodyComponent.cpp" />
@@ -62,17 +63,6 @@
     <ClInclude Include="..\..\source\Sound\include\SoundAttorney.h" />
     <ClInclude Include="..\..\source\UI\include\UIManager.h" />
     <ClInclude Include="..\..\source\UI\include\UIImplementation.h" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\bin\assets\scripts\Engine\Component.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\Entity.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\EntityLoader.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\EntityManager.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\initEngine.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\middleclass.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\namespace.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\System.lua" />
-    <None Include="..\..\bin\assets\scripts\Engine\test.lua" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <VCProjectVersion>16.0</VCProjectVersion>

--- a/vsprojects/PTSD-Core/PTSD.vcxproj.filters
+++ b/vsprojects/PTSD-Core/PTSD.vcxproj.filters
@@ -73,12 +73,6 @@
     <Filter Include="Core\Source">
       <UniqueIdentifier>{5868f7a0-2ac8-4aa6-ba4b-12afc2e7b7c8}</UniqueIdentifier>
     </Filter>
-    <Filter Include="Scripting\Scripts">
-      <UniqueIdentifier>{5678d39b-7abf-446d-ab81-6e3cd0016e94}</UniqueIdentifier>
-    </Filter>
-    <Filter Include="Scripting\Scripts\Engine">
-      <UniqueIdentifier>{c9bb1d3c-5b4c-4ce8-a8ba-7a9239354e22}</UniqueIdentifier>
-    </Filter>
     <Filter Include="Scripting\Headers\Components">
       <UniqueIdentifier>{22509197-678e-4236-af5d-fdadfc5dec5b}</UniqueIdentifier>
     </Filter>
@@ -152,6 +146,9 @@
     </ClCompile>
     <ClCompile Include="..\..\source\Core\src\PTSDVectors.cpp">
       <Filter>Core\Source</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\source\Scripting\source\Entity.cpp">
+      <Filter>Scripting\Source</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>
@@ -236,34 +233,5 @@
     <ClInclude Include="..\..\source\Core\include\BtOgre.h">
       <Filter>Core\Headers</Filter>
     </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\bin\assets\scripts\Engine\Component.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\Entity.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\EntityManager.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\initEngine.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\middleclass.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\namespace.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\System.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\test.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
-    <None Include="..\..\bin\assets\scripts\Engine\EntityLoader.lua">
-      <Filter>Scripting\Scripts\Engine</Filter>
-    </None>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Ya se refleja el borrado de entidades desde lua, como funciona es que nada mas borrar la entidad se llama al metodo disableEntity de la entidad en sí, que oculta el nodo de ogre y desactiva las colisiones.

Después se borran automáticamente todos los componentes según haga falta, esto se hace así porque parece que como usamos un unordered map hay cierto nivel de recoleccion de basura en el que se borra cada cierto tiempo, por lo que no se puede asumir que la entidad se borra automáticamente.