### PR TITLE
Tabla de colisiones fixed

### DIFF
--- a/bin/assets/scripts/Engine/EntityManager.lua
+++ b/bin/assets/scripts/Engine/EntityManager.lua
@@ -163,16 +163,12 @@ function EntityManager:registerCollision(ev)
 	local entA = self:getEntity(ev.entityAID)
 	local entB = self:getEntity(ev.entityBID)
 	local manifold = ev.manifold
-	if entA.id > entB.id then
-		local a = entA
-		entA = entB
-		entB = a
-	end
+	
 	if not self.collisions[entA.id] then self.collisions[entA.id] = {} end
-	if not self.collisions[entA.id][entB.id] then self.collisions[entA.id][entB.id] = {points = {}, entA = {}, entB = {}} end
-	self.collisions[entA.id][entB.id].entA = entA
-	self.collisions[entA.id][entB.id].entB = entB
-	table.insert(self.collisions[entA.id][entB.id].points, manifold)
+	if not self.collisions[entB.id] then self.collisions[entB.id] = {} end
+
+	self.collisions[entA.id][entB.id] =  {A = entA, B = entB, points=manifold}
+	self.collisions[entB.id][entA.id] =  {A = entB, B = entA, points=manifold}
 end
 
 function EntityManager:NotifyCollisions(system)

--- a/bin/assets/scripts/Engine/EntityManager.lua
+++ b/bin/assets/scripts/Engine/EntityManager.lua
@@ -177,7 +177,7 @@ function EntityManager:NotifyCollisions(system)
 		if t then
 			for i, other in pairs(t) do
 				local itable = self.collisions[ent.id][i]
-				system:onCollision(itable.entA, itable.entB, itable.points)
+				system:onCollision(itable.A, itable.B, itable.points)
 			end
 		end
 	end


### PR DESCRIPTION
Ahora nos aseguramos de guardar entradas en la tabla de colisiones para ambos objetos. Antes estaba asumiendo que con mantener un orden todo iba a salir bien y ser bonito, pero la experiencia demuestra lo contrario.