### PR TITLE
Pedir nombre de escena actual

### DIFF
--- a/bin/assets/scripts/Engine/EntityManager.lua
+++ b/bin/assets/scripts/Engine/EntityManager.lua
@@ -173,10 +173,15 @@ function EntityManager:changeScene(name)
 	self.newSceneName = name
 end
 
+function EntityManager:getCurrentSceneName()
+	return self.currentScene 
+end
+
 function EntityManager:changeSceneImpl(name)
 	--fire event so everyone holding reference to entities, wich they should not, and everyone who needs to change their state can do so
 	self.eventManager:fireEvent(namespace.ChangeSceneEvent(name))
 	self.requestedSceneChange = false;
+	self.currentScene = name
 
 	--remove all entities in lua side
 	for _, i in pairs(self.entities) do


### PR DESCRIPTION
El manager de entidades tiene un metodo para pedir el nombre de la escena actual. Sirve para el reset de TaiFighter